### PR TITLE
feat: Add loading spinners to CreateTestPage

### DIFF
--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface SpinnerProps {
+  size?: 'small' | 'medium' | 'large';
+  color?: string; // Allows custom color via tailwind classes e.g., 'text-blue-500'
+}
+
+const Spinner: React.FC<SpinnerProps> = ({ size = 'medium', color = 'text-sky-500' }) => {
+  let spinnerSizeClass = '';
+  switch (size) {
+    case 'small':
+      spinnerSizeClass = 'w-4 h-4 border-2';
+      break;
+    case 'medium':
+      spinnerSizeClass = 'w-8 h-8 border-4';
+      break;
+    case 'large':
+      spinnerSizeClass = 'w-12 h-12 border-4';
+      break;
+    default:
+      spinnerSizeClass = 'w-8 h-8 border-4';
+  }
+
+  return (
+    <div className="flex justify-center items-center">
+      <div
+        className={`animate-spin rounded-full ${spinnerSizeClass} border-t-transparent ${color}`}
+        style={{ borderTopColor: 'transparent' }} // Ensure transparent top border for spinning effect
+      ></div>
+    </div>
+  );
+};
+
+export default Spinner;

--- a/index.css
+++ b/index.css
@@ -2,7 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Custom styles */
+/* Add these if they don't exist, or if animate-spin is not working from Tailwind defaults */
+@layer utilities {
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .animate-spin {
+    animation: spin 1s linear infinite;
+  }
+}
+
+/* General body styles (example, might already exist) */
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -15,4 +27,4 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
-} 
+}


### PR DESCRIPTION
I integrated a new Spinner component into the CreateTestPage to provide visual feedback during asynchronous operations.

Spinners have been added to:
- Header buttons:
    - Load Page (during URL loading)
    - Detect Elements (during element detection)
    - Run Test (during test execution)
- ActionsPanel:
    - Generate Steps (during NLP step generation)
- ElementsPanel:
    - Displays a spinner while detecting elements.
- Load Test Modal:
    - Shows a spinner while saved tests are being loaded.

A new state variable `isLoadingSavedTests` was added to manage the loading state for tests in the Load Test Modal. The `useEffect` for loading initial tests has been updated to use this state.